### PR TITLE
Fix population bug

### DIFF
--- a/src/data_loader/population/population.py
+++ b/src/data_loader/population/population.py
@@ -75,7 +75,13 @@ def population_data_from_number(
     if num_nodes == 0:
         raise ValueError("No nodes found within the danger zone.")
 
-    population_per_node = population_number / num_nodes
+    if population_number < num_nodes:
+        logging.info(
+            "The population number is too small. The population number has now defaulted to 1 person per node."
+        )
+        population_per_node = 1.0
+    else:
+        population_per_node = population_number / num_nodes
 
     result = gpd.GeoDataFrame(
         {

--- a/src/routes/route.py
+++ b/src/routes/route.py
@@ -91,8 +91,7 @@ def create_route_objects(
     total_population = _get_total_population(population_data, cars_per_person)
     result = []
     departure_times = _departure_times(total_population, start, end)
-    for p in tqdm(list_of_paths):
-        route_path = p
+    for route_path in tqdm(list_of_paths):
         num_people_on_route = _get_num_people_on_route(
             route_path, population_data, cars_per_person
         )


### PR DESCRIPTION
Earlier, in cases where the population number was smaller than the number of nodes we could end up with rounding down to 0. This is fixed now by setting population per node to 1 in these cases